### PR TITLE
Rename AsyncStatus to AsyncPhase

### DIFF
--- a/Examples/Basic/APIRequestPage.swift
+++ b/Examples/Basic/APIRequestPage.swift
@@ -7,25 +7,25 @@ struct Post: Codable {
     let body: String
 }
 
-func useFetchPosts() -> (status: AsyncStatus<[Post], Error>, fetch: () -> Void) {
+func useFetchPosts() -> (phase: AsyncPhase<[Post], Error>, fetch: () -> Void) {
     let url = URL(string: "https://jsonplaceholder.typicode.com/posts").unsafelyUnwrapped
-    let (status, subscribe) = usePublisherSubscribe {
+    let (phase, subscribe) = usePublisherSubscribe {
         URLSession.shared.dataTaskPublisher(for: url)
             .map(\.data)
             .decode(type: [Post].self, decoder: JSONDecoder())
             .receive(on: DispatchQueue.main)
     }
 
-    return (status: status, fetch: subscribe)
+    return (phase: phase, fetch: subscribe)
 }
 
 struct APIRequestPage: HookView {
     var hookBody: some View {
-        let (status, fetch) = useFetchPosts()
+        let (phase, fetch) = useFetchPosts()
 
         return ScrollView {
             VStack {
-                switch status {
+                switch phase {
                 case .running:
                     ProgressView()
 

--- a/Examples/Basic/HookListPage.swift
+++ b/Examples/Basic/HookListPage.swift
@@ -141,21 +141,21 @@ struct HookListPage: HookView {
     }
 
     var usePublisherRow: some View {
-        let status = usePublisher(.once) {
+        let phase = usePublisher(.once) {
             Timer.publish(every: 1, on: .main, in: .common)
                 .autoconnect()
                 .prepend(Date())
         }
 
         return Row("usePublisher") {
-            if case .success(let date) = status {
+            if case .success(let date) = phase {
                 Text(DateFormatter.time.string(from: date))
             }
         }
     }
 
     var usePublisherSubscribeRow: some View {
-        let (status, subscribe) = usePublisherSubscribe {
+        let (phase, subscribe) = usePublisherSubscribe {
             Just(UUID())
                 .map(\.uuidString)
                 .delay(for: .seconds(1), scheduler: DispatchQueue.main)
@@ -163,7 +163,7 @@ struct HookListPage: HookView {
 
         return Row("usePublisherSubscribe") {
             Group {
-                switch status {
+                switch phase {
                 case .running:
                     ProgressView()
 

--- a/Examples/TheMovieDB/CustomHooks/UseFetch.swift
+++ b/Examples/TheMovieDB/CustomHooks/UseFetch.swift
@@ -6,7 +6,7 @@ func useFetch<Response: Decodable>(
     path: String,
     parameters: [String: String] = [:],
     onReceiveResponse: ((Response) -> Void)? = nil
-) -> (status: AsyncStatus<Response, URLError>, fetch: () -> Void) {
+) -> (phase: AsyncPhase<Response, URLError>, fetch: () -> Void) {
     func makeURLRequest() -> URLRequest {
         let url = URL(string: "https://api.themoviedb.org/3").unsafelyUnwrapped.appendingPathComponent(path)
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true).unsafelyUnwrapped
@@ -25,7 +25,7 @@ func useFetch<Response: Decodable>(
         return urlRequest
     }
 
-    let (status, subscribe) = usePublisherSubscribe {
+    let (phase, subscribe) = usePublisherSubscribe {
         URLSession.shared.dataTaskPublisher(for: makeURLRequest())
             .map(\.data)
             .decode(type: Response.self, decoder: jsonDecoder)
@@ -34,7 +34,7 @@ func useFetch<Response: Decodable>(
             .handleEvents(receiveOutput: onReceiveResponse)
     }
 
-    return (status: status, fetch: subscribe)
+    return (phase: phase, fetch: subscribe)
 }
 
 private let jsonDecoder: JSONDecoder = {

--- a/Examples/TheMovieDB/CustomHooks/UseFetchPage.swift
+++ b/Examples/TheMovieDB/CustomHooks/UseFetchPage.swift
@@ -5,22 +5,22 @@ func useFetchPage<Response: Decodable>(
     _: Response.Type,
     path: String,
     parameters: [String: String] = [:]
-) -> (status: AsyncStatus<[Response], URLError>, fetch: () -> Void) {
+) -> (phase: AsyncPhase<[Response], URLError>, fetch: () -> Void) {
     let page = useRef(0)
     let results = useRef([Response]())
 
     var parameters = parameters
     parameters["page"] = String(page.current + 1)
 
-    let (status, fetch) = useFetch(PagedResponse<Response>.self, path: path, parameters: parameters) { response in
+    let (phase, fetch) = useFetch(PagedResponse<Response>.self, path: path, parameters: parameters) { response in
         page.current = response.page
         results.current += response.results
     }
 
-    let newStatus =
+    let newPhase =
         page.current == 0
-        ? status.map { _ in results.current }
+        ? phase.map { _ in results.current }
         : .success(results.current)
 
-    return (status: newStatus, fetch: fetch)
+    return (phase: newPhase, fetch: fetch)
 }

--- a/Examples/TheMovieDB/CustomHooks/UseFetchTopRatedMovies.swift
+++ b/Examples/TheMovieDB/CustomHooks/UseFetchTopRatedMovies.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Hooks
 
-func useFetchTopRatedMovies() -> (status: AsyncStatus<[Movie], URLError>, fetch: () -> Void) {
+func useFetchTopRatedMovies() -> (phase: AsyncPhase<[Movie], URLError>, fetch: () -> Void) {
     useFetchPage(Movie.self, path: "movie/top_rated")
 }

--- a/Examples/TheMovieDB/CustomHooks/UseNetworkImage.swift
+++ b/Examples/TheMovieDB/CustomHooks/UseNetworkImage.swift
@@ -9,11 +9,11 @@ func useNetworkImage(for path: String, size: NetworkImageSize) -> UIImage? {
             .appendingPathComponent(path)
     }
 
-    let status = usePublisher(.preserved(by: [path, size.rawValue])) {
+    let phase = usePublisher(.preserved(by: [path, size.rawValue])) {
         URLSession.shared.dataTaskPublisher(for: makeURL())
             .map { data, _ in UIImage(data: data) }
             .receive(on: DispatchQueue.main)
     }
 
-    return status.value ?? nil
+    return phase.value ?? nil
 }

--- a/Examples/TheMovieDB/TopRatedMoviesPage.swift
+++ b/Examples/TheMovieDB/TopRatedMoviesPage.swift
@@ -3,12 +3,12 @@ import SwiftUI
 
 struct TopRatedMoviesPage: HookView {
     var hookBody: some View {
-        let (status, fetch) = useFetchTopRatedMovies()
+        let (phase, fetch) = useFetchTopRatedMovies()
         let selectedMovie = useState(nil as Movie?)
 
         NavigationView {
             Group {
-                switch status {
+                switch phase {
                 case .success(let page):
                     moviesList(page, onLoadMore: fetch) { movie in
                         selectedMovie.wrappedValue = movie

--- a/README.md
+++ b/README.md
@@ -214,15 +214,15 @@ let colorScheme = useEnvironment(\.colorScheme)  // ColorScheme
 <summary><CODE>usePublisher</CODE></summary>
 
 ```swift
-func usePublisher<P: Publisher>(_ computation: HookComputation, _ makePublisher: @escaping () -> P) -> AsyncStatus<P.Output, P.Failure>
+func usePublisher<P: Publisher>(_ computation: HookComputation, _ makePublisher: @escaping () -> P) -> AsyncPhase<P.Output, P.Failure>
 ```
 
-A hook to use the most recent status of asynchronous operation of the passed publisher.  
+A hook to use the most recent phase of asynchronous operation of the passed publisher.  
 The publisher will be subscribed at the first computation and will be re-subscribed according to the strategy specified with the passed `computation`.  
-Triggers a view update when the asynchronous status has been changed.  
+Triggers a view update when the asynchronous phase has been changed.  
 
 ```swift
-let status = usePublisher(.once) {
+let phase = usePublisher(.once) {
     URLSession.shared.dataTaskPublisher(for: url)
 }
 ```
@@ -233,14 +233,14 @@ let status = usePublisher(.once) {
 <summary><CODE>usePublisherSubscribe</CODE></summary>
 
 ```swift
-func usePublisherSubscribe<P: Publisher>(_ makePublisher: @escaping () -> P) -> (status: AsyncStatus<P.Output, P.Failure>, subscribe: () -> Void)
+func usePublisherSubscribe<P: Publisher>(_ makePublisher: @escaping () -> P) -> (phase: AsyncPhase<P.Output, P.Failure>, subscribe: () -> Void)
 ```
 
-A hook to use the most recent status of asynchronous operation of the passed publisher, and a `subscribe` function to be started to subscribe arbitrary timing.  
-Update the view with the asynchronous status change.  
+A hook to use the most recent phase of asynchronous operation of the passed publisher, and a `subscribe` function to be started to subscribe arbitrary timing.  
+Update the view with the asynchronous phase change.  
 
 ```swift
-let (status, subscribe) = usePublisherSubscribe {
+let (phase, subscribe) = usePublisherSubscribe {
     URLSession.shared.dataTaskPublisher(for: url)
 }
 ```

--- a/Sources/Hooks/AsyncPhase.swift
+++ b/Sources/Hooks/AsyncPhase.swift
@@ -1,16 +1,16 @@
-/// An immutable representation of the most recent asynchronous operation status.
+/// An immutable representation of the most recent asynchronous operation phase.
 @frozen
-public enum AsyncStatus<Success, Failure: Error> {
-    /// Represents a pending status meaning that the operation has not been started.
+public enum AsyncPhase<Success, Failure: Error> {
+    /// Represents a pending phase meaning that the operation has not been started.
     case pending
 
-    /// Represents a running status meaning that the operation has been started, but has not yet provided a result.
+    /// Represents a running phase meaning that the operation has been started, but has not yet provided a result.
     case running
 
-    /// Represents a success status meaning that the operation provided a value with success.
+    /// Represents a success phase meaning that the operation provided a value with success.
     case success(Success)
 
-    /// Represents a success status meaning that the operation provided an error with failure.
+    /// Represents a failure phase meaning that the operation provided an error with failure.
     case failure(Failure)
 
     /// Returns a Boolean value indicating whether this instance represents a `pending`.
@@ -61,7 +61,7 @@ public enum AsyncStatus<Success, Failure: Error> {
         return error
     }
 
-    /// Returns a result converted from the status.
+    /// Returns a result converted from the phase.
     /// If this instance represents a `pending` or a `running`, this returns nil.
     public var result: Result<Success, Failure>? {
         switch self {
@@ -76,24 +76,24 @@ public enum AsyncStatus<Success, Failure: Error> {
         }
     }
 
-    /// Returns a new status, mapping any success value using the given transformation.
+    /// Returns a new phase, mapping any success value using the given transformation.
     /// - Parameter transform: A closure that takes the success value of this instance.
-    /// - Returns: An `AsyncStatus` instance with the result of evaluating `transform` as the new success value if this instance represents a success.
-    public func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> AsyncStatus<NewSuccess, Failure> {
+    /// - Returns: An `AsyncPhase` instance with the result of evaluating `transform` as the new success value if this instance represents a success.
+    public func map<NewSuccess>(_ transform: (Success) -> NewSuccess) -> AsyncPhase<NewSuccess, Failure> {
         flatMap { .success(transform($0)) }
     }
 
     /// Returns a new result, mapping any failure value using the given transformation.
     /// - Parameter transform: A closure that takes the failure value of the instance.
-    /// - Returns: An `AsyncStatus` instance with the result of evaluating `transform` as the new failure value if this instance represents a failure.
-    public func mapError<NewFailure: Error>(_ transform: (Failure) -> NewFailure) -> AsyncStatus<Success, NewFailure> {
+    /// - Returns: An `AsyncPhase` instance with the result of evaluating `transform` as the new failure value if this instance represents a failure.
+    public func mapError<NewFailure: Error>(_ transform: (Failure) -> NewFailure) -> AsyncPhase<Success, NewFailure> {
         flatMapError { .failure(transform($0)) }
     }
 
-    /// Returns a new result, mapping any success value using the given transformation and unwrapping the produced status.
+    /// Returns a new result, mapping any success value using the given transformation and unwrapping the produced phase.
     /// - Parameter transform: A closure that takes the success value of the instance.
-    /// - Returns: An `AsyncStatus` instance, either from the closure or the previous `.success`.
-    public func flatMap<NewSuccess>(_ transform: (Success) -> AsyncStatus<NewSuccess, Failure>) -> AsyncStatus<NewSuccess, Failure> {
+    /// - Returns: An `AsyncPhase` instance, either from the closure or the previous `.success`.
+    public func flatMap<NewSuccess>(_ transform: (Success) -> AsyncPhase<NewSuccess, Failure>) -> AsyncPhase<NewSuccess, Failure> {
         switch self {
         case .pending:
             return .pending
@@ -109,10 +109,10 @@ public enum AsyncStatus<Success, Failure: Error> {
         }
     }
 
-    /// Returns a new result, mapping any failure value using the given transformation and unwrapping the produced status.
+    /// Returns a new result, mapping any failure value using the given transformation and unwrapping the produced phase.
     /// - Parameter transform: A closure that takes the failure value of the instance.
-    /// - Returns: An `AsyncStatus` instance, either from the closure or the previous `.failure`.
-    public func flatMapError<NewFailure: Error>(_ transform: (Failure) -> AsyncStatus<Success, NewFailure>) -> AsyncStatus<Success, NewFailure> {
+    /// - Returns: An `AsyncPhase` instance, either from the closure or the previous `.failure`.
+    public func flatMapError<NewFailure: Error>(_ transform: (Failure) -> AsyncPhase<Success, NewFailure>) -> AsyncPhase<Success, NewFailure> {
         switch self {
         case .pending:
             return .pending
@@ -129,5 +129,5 @@ public enum AsyncStatus<Success, Failure: Error> {
     }
 }
 
-extension AsyncStatus: Equatable where Success: Equatable, Failure: Equatable {}
-extension AsyncStatus: Hashable where Success: Hashable, Failure: Hashable {}
+extension AsyncPhase: Equatable where Success: Equatable, Failure: Equatable {}
+extension AsyncPhase: Hashable where Success: Hashable, Failure: Hashable {}

--- a/Tests/HooksTests/AsyncPhaseTests.swift
+++ b/Tests/HooksTests/AsyncPhaseTests.swift
@@ -1,9 +1,9 @@
 import Hooks
 import XCTest
 
-final class AsyncStatusTests: XCTestCase {
+final class AsyncPhaseTests: XCTestCase {
     func testIsPending() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -17,13 +17,13 @@ final class AsyncStatusTests: XCTestCase {
             false,
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.isPending, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.isPending, expected)
         }
     }
 
     func testIsRunning() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -37,13 +37,13 @@ final class AsyncStatusTests: XCTestCase {
             false,
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.isRunning, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.isRunning, expected)
         }
     }
 
     func testIsSuccess() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -57,13 +57,13 @@ final class AsyncStatusTests: XCTestCase {
             false,
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.isSuccess, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.isSuccess, expected)
         }
     }
 
     func testIsFailure() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -77,13 +77,13 @@ final class AsyncStatusTests: XCTestCase {
             true,
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.isFailure, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.isFailure, expected)
         }
     }
 
     func testValue() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -97,13 +97,13 @@ final class AsyncStatusTests: XCTestCase {
             nil,
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.value, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.value, expected)
         }
     }
 
     func testError() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -117,13 +117,13 @@ final class AsyncStatusTests: XCTestCase {
             URLError(.badURL),
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.error, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.error, expected)
         }
     }
 
     func testResult() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
@@ -137,95 +137,95 @@ final class AsyncStatusTests: XCTestCase {
             .failure(URLError(.badURL)),
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.result, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.result, expected)
         }
     }
 
     func testMap() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
             .failure(URLError(.badURL)),
         ]
 
-        let expected: [AsyncStatus<Int, URLError>] = [
+        let expected: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(100),
             .failure(URLError(.badURL)),
         ]
 
-        for (status, expected) in zip(statuses, expected) {
-            XCTAssertEqual(status.map { _ in 100 }, expected)
+        for (phase, expected) in zip(phases, expected) {
+            XCTAssertEqual(phase.map { _ in 100 }, expected)
         }
     }
 
     func testMapError() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
             .failure(URLError(.badURL)),
         ]
 
-        let expected: [AsyncStatus<Int, URLError>] = [
+        let expected: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
             .failure(URLError(.cancelled)),
         ]
 
-        for (status, expected) in zip(statuses, expected) {
+        for (phase, expected) in zip(phases, expected) {
             XCTAssertEqual(
-                status.mapError { _ in URLError(.cancelled) },
+                phase.mapError { _ in URLError(.cancelled) },
                 expected
             )
         }
     }
 
     func testFlatMap() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
             .failure(URLError(.badURL)),
         ]
 
-        let expected: [AsyncStatus<Int, URLError>] = [
+        let expected: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .failure(URLError(.callIsActive)),
             .failure(URLError(.badURL)),
         ]
 
-        for (status, expected) in zip(statuses, expected) {
+        for (phase, expected) in zip(phases, expected) {
             XCTAssertEqual(
-                status.flatMap { _ in .failure(URLError(.callIsActive)) },
+                phase.flatMap { _ in .failure(URLError(.callIsActive)) },
                 expected
             )
         }
     }
 
     func testFlatMapError() {
-        let statuses: [AsyncStatus<Int, URLError>] = [
+        let phases: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
             .failure(URLError(.badURL)),
         ]
 
-        let expected: [AsyncStatus<Int, URLError>] = [
+        let expected: [AsyncPhase<Int, URLError>] = [
             .pending,
             .running,
             .success(0),
             .success(100),
         ]
 
-        for (status, expected) in zip(statuses, expected) {
+        for (phase, expected) in zip(phases, expected) {
             XCTAssertEqual(
-                status.flatMapError { _ in .success(100) },
+                phase.flatMapError { _ in .success(100) },
                 expected
             )
         }

--- a/Tests/HooksTests/Hook/PublisherHookTests.swift
+++ b/Tests/HooksTests/Hook/PublisherHookTests.swift
@@ -12,7 +12,7 @@ final class PublisherHookTests: XCTestCase {
 
         let state = hook.makeState()
 
-        XCTAssertEqual(state.status, .pending)
+        XCTAssertEqual(state.phase, .pending)
         XCTAssertNil(state.cancellable)
     }
 
@@ -27,11 +27,11 @@ final class PublisherHookTests: XCTestCase {
                 updateView: {}
             )
 
-        coordinator.state.status = .success(100)
+        coordinator.state.phase = .success(100)
 
-        let status = hook.makeValue(coordinator: coordinator)
+        let phase = hook.makeValue(coordinator: coordinator)
 
-        XCTAssertEqual(status, .success(100))
+        XCTAssertEqual(phase, .success(100))
     }
 
     func testCompute() {
@@ -50,28 +50,28 @@ final class PublisherHookTests: XCTestCase {
             )
 
         XCTAssertNil(coordinator.state.cancellable)
-        XCTAssertEqual(coordinator.state.status, .pending)
+        XCTAssertEqual(coordinator.state.phase, .pending)
         XCTAssertEqual(viewUpdatedCount, 0)
 
         hook.compute(coordinator: coordinator)
 
         XCTAssertNotNil(coordinator.state.cancellable)
-        XCTAssertEqual(coordinator.state.status, .running)
+        XCTAssertEqual(coordinator.state.phase, .running)
         XCTAssertEqual(viewUpdatedCount, 1)
 
         subject.send(0)
 
-        XCTAssertEqual(coordinator.state.status, .success(0))
+        XCTAssertEqual(coordinator.state.phase, .success(0))
         XCTAssertEqual(viewUpdatedCount, 2)
 
         subject.send(1)
 
-        XCTAssertEqual(coordinator.state.status, .success(1))
+        XCTAssertEqual(coordinator.state.phase, .success(1))
         XCTAssertEqual(viewUpdatedCount, 3)
 
         subject.send(completion: .failure(URLError(.badURL)))
 
-        XCTAssertEqual(coordinator.state.status, .failure(URLError(.badURL)))
+        XCTAssertEqual(coordinator.state.phase, .failure(URLError(.badURL)))
         XCTAssertEqual(viewUpdatedCount, 4)
     }
 

--- a/Tests/HooksTests/Hook/PublisherSubscribeTests.swift
+++ b/Tests/HooksTests/Hook/PublisherSubscribeTests.swift
@@ -12,7 +12,7 @@ final class PublisherSubscribeHookTests: XCTestCase {
 
         let state = hook.makeState()
 
-        XCTAssertEqual(state.status, .pending)
+        XCTAssertEqual(state.phase, .pending)
         XCTAssertFalse(state.isDisposed)
         XCTAssertNil(state.cancellable)
     }
@@ -33,7 +33,7 @@ final class PublisherSubscribeHookTests: XCTestCase {
             )
 
         XCTAssertNil(coordinator.state.cancellable)
-        XCTAssertEqual(coordinator.state.status, .pending)
+        XCTAssertEqual(coordinator.state.phase, .pending)
         XCTAssertEqual(viewUpdatedCount, 0)
 
         let (_, subscribe) = hook.makeValue(coordinator: coordinator)
@@ -41,28 +41,28 @@ final class PublisherSubscribeHookTests: XCTestCase {
         subject.send(0)
 
         XCTAssertNil(coordinator.state.cancellable)
-        XCTAssertEqual(coordinator.state.status, .pending)
+        XCTAssertEqual(coordinator.state.phase, .pending)
         XCTAssertEqual(viewUpdatedCount, 0)
 
         subscribe()
 
         XCTAssertNotNil(coordinator.state.cancellable)
-        XCTAssertEqual(coordinator.state.status, .running)
+        XCTAssertEqual(coordinator.state.phase, .running)
         XCTAssertEqual(viewUpdatedCount, 1)
 
         subject.send(0)
 
-        XCTAssertEqual(coordinator.state.status, .success(0))
+        XCTAssertEqual(coordinator.state.phase, .success(0))
         XCTAssertEqual(viewUpdatedCount, 2)
 
         subject.send(1)
 
-        XCTAssertEqual(coordinator.state.status, .success(1))
+        XCTAssertEqual(coordinator.state.phase, .success(1))
         XCTAssertEqual(viewUpdatedCount, 3)
 
         subject.send(completion: .failure(URLError(.badURL)))
 
-        XCTAssertEqual(coordinator.state.status, .failure(URLError(.badURL)))
+        XCTAssertEqual(coordinator.state.phase, .failure(URLError(.badURL)))
         XCTAssertEqual(viewUpdatedCount, 4)
     }
 
@@ -88,7 +88,7 @@ final class PublisherSubscribeHookTests: XCTestCase {
         subscribe()
 
         XCTAssertNil(coordinator.state.cancellable)
-        XCTAssertEqual(coordinator.state.status, .pending)
+        XCTAssertEqual(coordinator.state.phase, .pending)
         XCTAssertEqual(viewUpdatedCount, 0)
     }
 


### PR DESCRIPTION
### Breaking change
[AsyncImagePhase](https://developer.apple.com/documentation/swiftui/asyncimagephase) has been added on iOS15 and it's quite similar to `AsyncStatus` so it would make more sense if they have a similar name.