### PR TITLE
feat: Remove deprecated API

### DIFF
--- a/Sources/Hooks/Hook.swift
+++ b/Sources/Hooks/Hook.swift
@@ -36,14 +36,6 @@ public protocol Hook {
 }
 
 public extension Hook {
-    /// Register the hook to the view and returns its value.
-    /// Must be called at the function top level within scope of the HookScope or the HookView.hookBody`.
-    /// - Returns: A value that this hook provides.
-    @available(*, deprecated, message: "This function will be removed soon. Use toplevel `useHook` instead.")
-    func use() -> Value {
-        useHook(self)
-    }
-
     /// Indicates whether the value should be computed after all hooks have been evaluated.
     /// Default is `false`.
     var shouldDeferredCompute: Bool { false }

--- a/Tests/HooksTests/HookDispatcherTests.swift
+++ b/Tests/HooksTests/HookDispatcherTests.swift
@@ -127,7 +127,6 @@ final class HookDispatcherTests: XCTestCase {
 
         dispatcher.scoped(disablesAssertion: true, environment: EnvironmentValues()) {
             let value1 = useHook(hook1)
-            // _ = hook2.use()
             let value3 = useHook(hook3)
             let value4 = useHook(hook4)
 
@@ -145,7 +144,6 @@ final class HookDispatcherTests: XCTestCase {
 
         dispatcher.scoped(disablesAssertion: false, environment: EnvironmentValues()) {
             let value1 = useHook(hook1)
-            // _ = hook2.use()
             let value3 = useHook(hook3)
             let value4 = useHook(hook4)
 
@@ -176,8 +174,6 @@ final class HookDispatcherTests: XCTestCase {
         dispatcher.scoped(disablesAssertion: true, environment: EnvironmentValues()) {
             // There is 1 hook
             let value1 = useHook(hook1)
-            // let value2 = hook2.use()
-            // let value3 = hook3.use()
 
             XCTAssertEqual(value1, 2)  // Works correctly
         }

--- a/Tests/HooksTests/HookTests.swift
+++ b/Tests/HooksTests/HookTests.swift
@@ -13,7 +13,7 @@ final class HookTests: XCTestCase {
         }
     }
 
-    func testUse() {
+    func testUseHook() {
         let dispatcher = HookDispatcher()
         let hook = TestHook()
 


### PR DESCRIPTION
Remove `Hook.use()` as it's already marked as deprecated.