### PR TITLE
fix: Remove unsafe flags from the package definition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,7 @@ let package = Package(
         .library(name: "Hooks", targets: ["Hooks"])
     ],
     targets: [
-        .target(
-            name: "Hooks",
-            swiftSettings: [
-                .unsafeFlags([
-                    "-Xfrontend",
-                    "-enable-actor-data-race-checks",
-                ])
-            ]
-        ),
+        .target(name: "Hooks"),
         .testTarget(
             name: "HooksTests",
             dependencies: ["Hooks"]


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Issue for this PR

Link: https://github.com/ra1028/swiftui-hooks/issues/23

## Description

The Package.swift file contained `unsafeFlags` to check actor data race with runtime warnings, but it was blocking to use the package as a dependency in an external project. The PR just removes them.

## Impact on Existing Code

Nothing

