### PR TITLE
Cleanup after an effect before executing a new one

### DIFF
--- a/Sources/Hooks/Hook/UseEffect.swift
+++ b/Sources/Hooks/Hook/UseEffect.swift
@@ -63,18 +63,18 @@ private struct EffectHook: Hook {
     }
 
     func updateState(coordinator: Coordinator) {
+        coordinator.state.cleanup?()
         coordinator.state.cleanup = effect()
     }
 
     func dispose(state: State) {
+        state.cleanup?()
         state.cleanup = nil
     }
 }
 
 private extension EffectHook {
     final class State {
-        var cleanup: (() -> Void)? {
-            didSet { oldValue?() }
-        }
+        var cleanup: (() -> Void)?
     }
 }


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Issue for this PR

Link: N/A

## Description

Fixes issue where effects with dependencies (eg `.preserved(by:)`) would cleanup itself **after** new effect ran. This is different behavior from React's implementation and could cause unexpected results.

## Motivation and Context

Running the following code with Hooks v0.6.0, after tapping the button, `useHook` would first run new effect, then cleanup after previous effect. The timeline is:

1. [Key: 1]
2. Run Effect [1]
3. Increment key [Key: 2]
4. Run Effect [2]
5. Cleanup Effect [1]

Steps 4 and 5 should run in opposite order.

The issue emerges in `UseEffectHook.State` in `willSet` property observer. The observation triggers old effect's cleanup by `oldValue?()` by which time new effect already finished to return new cleanup closure.

<details>
<summary>SwiftUI Code</summary>

```swift
func App() -> some View {
    HookScope {
        let state = useState(0)
        let _ = useEffect(.preserved(by: state.wrappedValue)) {
            print("subscribe \(state.wrappedValue)")
            return {
                print("unsubscribe \(state.wrappedValue)")
            }
        }

        Text(state.wrappedValue.description)
        Button("Add") {
            state.wrappedValue += 1
        }
    }
}
```

</details>

<details>
<summary>React Code</summary>

```typescript
function App() {
  const [state, setState] = React.useState(0);

  useEffect(() => {
    console.log("subscribe " + state);

    return () => console.log("unsubscribe " + state);
  }, [state]);

  return (
    <div>
      <p>{state}</p>
      <button onClick={() => setState((old) => old + 1)}>Add</button>
    </div>
  );
}
```

Running the sample code in `patch-1` branch, the results are same as React app above.

</details>

## Impact on Existing Code

The change is source-compatible.

## Screenshot/Video/Gif
