### PR TITLE
Enable animations in state hook

### DIFF
--- a/Sources/Hooks/Hook/UseState.swift
+++ b/Sources/Hooks/Hook/UseState.swift
@@ -28,15 +28,17 @@ private struct StateHook<State>: Hook {
             get: {
                 coordinator.state.state
             },
-            set: { newState in
+            set: { newState, transaction in
                 assertMainThread()
 
                 guard !coordinator.state.isDisposed else {
                     return
                 }
 
-                coordinator.state.state = newState
-                coordinator.updateView()
+                withAnimation(transaction.animation) {
+                    coordinator.state.state = newState
+                    coordinator.updateView()
+                }
             }
         )
     }

--- a/Sources/Hooks/Hook/UseState.swift
+++ b/Sources/Hooks/Hook/UseState.swift
@@ -35,7 +35,7 @@ private struct StateHook<State>: Hook {
                     return
                 }
 
-                withAnimation(transaction.animation) {
+                withTransaction(transaction) {
                     coordinator.state.state = newState
                     coordinator.updateView()
                 }


### PR DESCRIPTION
## Pull Request Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Issue for this PR

Link: N/A

## Description

This PR fixes a bug occurring when a user is trying to animate `useState` changes using `.animation()` modifier.

I could not find any way to test the code correctly or at least to create failing test - any tips on that? 

## Motivation and Context

Given following code:

```swift
let myState = useState(..).animation(.default)
...
...
myState.wrappedValue = ...
```

* Expected behavior: Views will animate transition between state changes
* Actual: View re-renders itself on state change, but `.default` animation is ignored and the transition is immediate.

<details>
<summary>Demo app source code</summary>

```swift
struct App: View {
    @State private var animate: Bool = true
    @State private var isRounded: Bool = true

    var body: some View {
        Form {
            Section {
                Toggle("Animate changes", isOn: $animate)
            }

            SwiftUIStateDemo(animateChanges: animate)

            HooksStateDemo(animateChanges: animate)
        }
    }
}

struct SwiftUIStateDemo: View {
    var animateChanges: Bool
    @State private var isRounded: Bool = false

    var body: some View {
        Section("Plain SwiftUI State") {
            Preview(isRounded: $isRounded.animation(animateChanges ? .default : nil))
        }
    }
}

func HooksStateDemo(animateChanges: Bool) -> some View {
    HookScope {
        let isRounded = useState(false).animation(animateChanges ? .default : nil)

        Section("Hooks State") {
            Preview(isRounded: isRounded.animation(animateChanges ? .default : nil))
        }
    }
}

func Preview(isRounded: Binding<Bool>) -> some View {
    HStack {
        Button("Change", action: { isRounded.wrappedValue.toggle() })
            .buttonStyle(.bordered)

        Spacer()

        Color.red
            .frame(width: 50, height: 50)
            .cornerRadius(isRounded.wrappedValue ? 25 : 0)
    }
}
```
</details>

## Impact on Existing Code

This change is source-compatible, the fix will only affect users if they use `.animation()` modifier on state binding.

## Screenshot/Video/Gif

| `main` branch | Pull Request |
|-----|-----|
| <video src="https://user-images.githubusercontent.com/5204614/175561492-e08c1c3b-b62a-49ae-aba3-b963c0107261.mov" /> | <video src="https://user-images.githubusercontent.com/5204614/175561546-a6f65b08-21f9-4046-89c9-592531753881.mov" /> |
