### PR TITLE
Lazy initial state using closures in useState hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,28 @@ And then, include "Hooks" as a dependency for your target:
 
 ```swift
 func useState<State>(_ initialState: State) -> Binding<State>
+func useState<State>(_ initialState: @escaping () -> State) -> Binding<State>
 ```
 
 A hook to use a `Binding<State>` wrapping current state to be updated by setting a new state to `wrappedValue`.  
-Triggers a view update when the state has been changed.  
+Triggers a view update when the state has been changed.
 
 ```swift
 let count = useState(0)  // Binding<Int>
+
+Button("Increment") {
+    count.wrappedValue += 1
+}
+```
+
+If the initial state is the result of an expensive computation, you may provide a closure instead.
+The closure will be executed once, during the initial render.
+
+```swift
+let count = useState {
+    let initialState = expensiveComputation() // Int
+    return initialState
+}                                             // Binding<Int>
 
 Button("Increment") {
     count.wrappedValue += 1

--- a/Sources/Hooks/Hook/UseState.swift
+++ b/Sources/Hooks/Hook/UseState.swift
@@ -3,6 +3,24 @@ import SwiftUI
 /// A hook to use a `Binding<State>` wrapping current state to be updated by setting a new state to `wrappedValue`.
 /// Triggers a view update when the state has been changed.
 ///
+///     let count = useState {
+///         let initialState = expensiveComputation() // Int
+///         return initialState
+///     }                                             // Binding<Int>
+///
+///     Button("Increment") {
+///         count.wrappedValue += 1
+///     }
+///
+/// - Parameter initialState: A closure creating an initial state. The closure will only be called once, during the initial render.
+/// - Returns: A `Binding<State>` wrapping current state.
+public func useState<State>(_ initialState: @escaping () -> State) -> Binding<State> {
+    useHook(StateHook(initialState: initialState))
+}
+
+/// A hook to use a `Binding<State>` wrapping current state to be updated by setting a new state to `wrappedValue`.
+/// Triggers a view update when the state has been changed.
+///
 ///     let count = useState(0)  // Binding<Int>
 ///
 ///     Button("Increment") {
@@ -12,15 +30,17 @@ import SwiftUI
 /// - Parameter initialState: An initial state.
 /// - Returns: A `Binding<State>` wrapping current state.
 public func useState<State>(_ initialState: State) -> Binding<State> {
-    useHook(StateHook(initialState: initialState))
+    useState {
+        initialState
+    }
 }
 
 private struct StateHook<State>: Hook {
-    let initialState: State
+    let initialState: () -> State
     var updateStrategy: HookUpdateStrategy? = .once
 
     func makeState() -> Ref {
-        Ref(initialState: initialState)
+        Ref(initialState: initialState())
     }
 
     func value(coordinator: Coordinator) -> Binding<State> {

--- a/Sources/Hooks/Hooks.docc/Hooks.md
+++ b/Sources/Hooks/Hooks.docc/Hooks.md
@@ -16,7 +16,8 @@ Furthermore, hooks such as useEffect also solve the problem of lack of lifecycle
 
 ### Hooks
 
-- ``useState(_:)``
+- ``useState(_:)-52rjz``
+- ``useState(_:)-jg02``
 - ``useEffect(_:_:)``
 - ``useLayoutEffect(_:_:)``
 - ``useMemo(_:_:)``

--- a/Tests/HooksTests/Hook/UseStateTests.swift
+++ b/Tests/HooksTests/Hook/UseStateTests.swift
@@ -41,6 +41,54 @@ final class UseStateTests: XCTestCase {
         XCTAssertEqual(tester.value.wrappedValue, 0)
     }
 
+    func testInitialStateCreatedOnEachUpdate() {
+        var updateCalls = 0
+
+        func createState() -> Int {
+            updateCalls += 1
+            return 0
+        }
+
+        let tester = HookTester {
+            useState(createState())
+        }
+
+        XCTAssertEqual(updateCalls, 1)
+
+        tester.update()
+
+        XCTAssertEqual(updateCalls, 2)
+
+        tester.update()
+
+        XCTAssertEqual(updateCalls, 3)
+    }
+
+    func testInitialStateCreateOnceWhenGivenClosure() {
+        var closureCalls = 0
+
+        func createState() -> Int {
+            closureCalls += 1
+            return 0
+        }
+
+        let tester = HookTester {
+            useState {
+                createState()
+            }
+        }
+
+        XCTAssertEqual(closureCalls, 1)
+
+        tester.update()
+
+        XCTAssertEqual(closureCalls, 1)
+
+        tester.update()
+
+        XCTAssertEqual(closureCalls, 1)
+    }
+
     func testDispose() {
         let tester = HookTester {
             useState(0)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Chore

## Issue for this PR

Link: #27

## Description

Implements feature request #27 (closures for initial state in `useState`). The solution implements Option 2 from the linked issue.

Looking for an overall feedback on the updated documentation 🙏.

## Motivation and Context

Adds support for instantiating initial state in `useState` hook. This might help with app performance in some specific cases. Described into detail in linked issue.

## Impact on Existing Code

Source compatible up-to edge cases (see discussion in #27).

## Screenshot/Video/Gif

N/A
